### PR TITLE
Compatibility check fix & potential exception fix

### DIFF
--- a/Assets/Aura/Classes/Aura.cs
+++ b/Assets/Aura/Classes/Aura.cs
@@ -367,7 +367,7 @@ namespace AuraAPI
         {
 #if UNITY_2017_2_OR_NEWER
             bool isCompatible =
-                SystemInfo.graphicsShaderLevel >= 50 &&                                                     // For compute shader support
+                SystemInfo.graphicsShaderLevel >= 45 &&                                                     // For compute shader support
                 SystemInfo.supports2DArrayTextures &&                                                       // Uses Texture2DArrays for packing textures
                 SystemInfo.supports3DTextures &&                                                            // For volumetric texture masks and point shadows
                 SystemInfo.supports3DRenderTextures &&                                                      // For point shadows

--- a/Assets/Aura/Classes/Frustum.cs
+++ b/Assets/Aura/Classes/Frustum.cs
@@ -327,6 +327,11 @@ namespace AuraAPI
         /// </summary>
         public void Dispose()
         {
+            // Make sure that _buffers is initialised prior to releasing it. There's a
+            // possibility that Dispose is called before CreateBuffers resulting in an
+            // unfortunate exception.
+            if(!_buffers) return;
+
             _buffers.ReleaseBuffers();
         }
 


### PR DESCRIPTION
This PR contains two fixes:

1. It checks against the correct graphic shader level: `45 - compute shader support` instead of `50 - DX11`
2. A `_buffers` check in `Dispose` which would otherwise result in an exception when called prior to `CreateBuffers`.

1: I googled for macos support and found a [reddit thread](https://www.reddit.com/r/Unity3D/comments/7r977e/aura_volumetric_lighting_for_unity_reveal_teaser/dswokia/) in which the OP said (assuming that is you) it doesn't use any platform specific features and second, the comment on line `370` specifies "compute shader support". Is this correct or do you target Windows only?

2: I encountered `2` when I first tried one of the examples on *macos*, which without the fix in 1 disables aura and attempts to dispose of the frustum, releasing the internal buffer. Unfortunately the buffer isn't initialised, which results in a null exception because of `_buffers`.

The issue remains that it doesn't work so hence the question in `1`. Even with the fixes above I get really dodgy artefacts including odd looking magenta imaging. If there's anything I can do to help fix or test this let me know and I can include it in the PR.

My system:

iMac Pro Intel Xeon W
Radeon Pro Vega 64 w/ 16GB memory
