### PR TITLE
Initialise AuraLight in Start rather than OnEnable

### DIFF
--- a/Assets/Aura/Classes/AuraLight.cs
+++ b/Assets/Aura/Classes/AuraLight.cs
@@ -211,10 +211,11 @@ namespace AuraAPI
             _lightComponent = GetComponent<Light>();
         }
 
-        private void OnEnable()
+        private void Start()
         {
             if(!Aura.CheckCompatibility())
             {
+                Debug.LogError("Not compatible, disabling AuraLight");
                 enabled = false;
                 return;
             }
@@ -225,11 +226,12 @@ namespace AuraAPI
             }
             else
             {
+                Debug.LogError("No Aura instance, disabling AuraLight");
                 enabled = false;
             }
         }
 
-        private void OnDisable()
+        private void OnDestroy()
         {
             if(_isInitialized)
             {


### PR DESCRIPTION
This is one potential solution to #18 - a race condition was causing some lights to be permanently disabled during compiles/builds etc when re-initialising as there is no guarantee that Aura.HasInstance yet, and if this code runs before that point then it's permanently disabled in the editor. By moving it to Start it's guaranteed that regardless of the object hierarchy etc. this will run after Aura.HasInstance. As far as I can determine this doesn't have any adverse effects on the functionality.